### PR TITLE
Use exec in the shim script

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -125,7 +125,7 @@ install_from_bin_package() {
     #  we obtained using $HOME which is absolute, but if that changes
     #  and it is not absolute any more, .sh file generated below
     #  will not work properly.
-    printf '#!/bin/sh\nwaspc_datadir=%s/data %s/wasp-bin "$@"\n' "$DATA_DST_DIR" "$DATA_DST_DIR" \
+    printf '#!/bin/sh\nwaspc_datadir=%s/data exec %s/wasp-bin "$@"\n' "$DATA_DST_DIR" "$DATA_DST_DIR" \
            > "$BIN_DST_DIR/wasp"
     if ! chmod +x "$BIN_DST_DIR/wasp"; then
         die "Failed to make $BIN_DST_DIR/wasp executable."


### PR DESCRIPTION
## TL;DR

When running `wasp` in the terminal, we'll now see the process title:

![image](https://github.com/user-attachments/assets/3dde9695-d6ef-4126-b7ca-b1569a7d8154)

## Problem

Right now, when running `wasp start`, the terminal that is running it will have the title `sh` or `bash` instead of `wasp-bin`:

This is because of our shim script, as installed at `~/.local/bin/wasp`. It just runs our binary normally, so this is interpreted as a regular script calling wasp as part of its steps.

The process hierarchy ends up something like this:

![image](https://github.com/user-attachments/assets/532489dd-aedf-49c3-9263-9457b1075975)

This is not a big perf hit, but it's a bit careless and the terminal tab doesn't show that we're running Wasp so it's easy to mix it up.

## Solution

I modified our installer so the shim script ends up being something like:

```diff
 #!/bin/sh
-waspc_datadir=path/to/data path/to/bin "$@"
+waspc_datadir=path/to/data exec path/to/bin "$@"
```

[From the POSIX specification
](https://pubs.opengroup.org/onlinepubs/000095399/utilities/exec.html)

> If exec is specified with command, it shall replace the shell with command without creating a new process. 

This means that our process hierarchy ends up being this one:

![image](https://github.com/user-attachments/assets/de9b3f20-1743-42b1-83e0-1819c98bcbe1)
