### PR TITLE
Allow installing from a file instead of a named version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           --repo wasp-lang/wasp \
           --name $package_name
         env:
+          GH_TOKEN: ${{ github.token }}
           package_name: wasp-cli-${{ runner.os == 'Linux' && 'linux' || 'macos' }}-${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}
 
       - name: Edit PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,23 +47,9 @@ jobs:
 
       - name: Download installer package
         if: matrix.args.needs-download == true
-        run: |
-          run_id=$(
-            gh run list \
-              --repo wasp-lang/wasp \
-              --workflow CI \
-              --branch main \
-              --status success \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId'
-          )
-          gh run download $run_id \
-          --repo wasp-lang/wasp \
-          --name $package_name
-        env:
-          GH_TOKEN: ${{ github.token }}
-          package_name: wasp-cli-${{ runner.os == 'Linux' && 'linux' || 'macos' }}-${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}
+        # TODO: Change the reference to `main` once that PR is merged:
+        # https://github.com/wasp-lang/wasp/pull/3304
+        uses: wasp-lang/wasp/.github/actions/fetch-nightly-cli@cprecioso/create-nightly-action
 
       - name: Edit PATH
         run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
             value: ""
           - name: versioned
             value: "-v 0.18.0"
+          - name: file path
+            value: "-f ./wasp-*.tar.gz"
+            needs-download: true
         exclude:
           # Dash is not available on macOS.
           - { os: macos-latest, shell: dash }
@@ -41,6 +44,25 @@ jobs:
       - name: Install shell
         if: runner.os == 'Linux'
         run: sudo apt-get install -y ${{ matrix.shell }}
+
+      - name: Download installer package
+        if: matrix.args.needs-download == true
+        run: |
+          run_id=$(
+            gh run list \
+              --repo wasp-lang/wasp \
+              --branch main \
+              --status completed \
+              --event push \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId'
+          )
+          gh run download $run_id \
+          --repo wasp-lang/wasp \
+          --name $package_name
+        env:
+          package_name: wasp-cli-${{ runner.os == 'Linux' && 'linux' || 'macos' }}-${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}
 
       - name: Edit PATH
         run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Download installer package
         if: matrix.args.needs-download == true
-        # TODO: Change the reference to `main` once that PR is merged:
-        # https://github.com/wasp-lang/wasp/pull/3304
-        uses: wasp-lang/wasp/.github/actions/fetch-nightly-cli@cprecioso/create-nightly-action
+        uses: wasp-lang/wasp/.github/actions/fetch-nightly-cli@main
 
       - name: Edit PATH
         run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,9 @@ jobs:
           run_id=$(
             gh run list \
               --repo wasp-lang/wasp \
+              --workflow CI \
               --branch main \
-              --status completed \
-              --event push \
+              --status success \
               --limit 1 \
               --json databaseId \
               --jq '.[0].databaseId'

--- a/installer.sh
+++ b/installer.sh
@@ -50,19 +50,9 @@ main() {
     bin_dst_dir="$HOME_LOCAL_BIN"
 
     if [ -n "$FILE_ARG" ]; then
-        if [ -f "$FILE_ARG" ]; then
-            install_from_package_file "$FILE_ARG" "$data_dst_dir"
-        else
-            die "The specified file does not exist: $FILE_ARG"
-        fi
+        install_using_file_arg "$data_dst_dir"
     else
-        if [ -z "$(ls -A "$data_dst_dir")" ]; then
-            package_url=$(decide_package_url_for_version "$version_name")
-            package_file=$(download_package_url "$version_name" "$package_url")
-            install_from_package_file "$package_file" "$data_dst_dir"
-        else
-            info "Found an existing installation on the disk, at $data_dst_dir. Using it instead.\n"
-        fi
+        install_using_version "$version_name" "$data_dst_dir"
     fi
 
     link_wasp_version "$version_name" "$data_dst_dir" "$bin_dst_dir"
@@ -88,6 +78,29 @@ decide_version_name() {
         info "Installing wasp version $version_name ($latest_version_message).\n"
 
         echo "$version_name"
+    fi
+}
+
+install_using_file_arg() {
+    data_dst_dir=$1
+
+    if [ -f "$FILE_ARG" ]; then
+        install_from_package_file "$FILE_ARG" "$data_dst_dir"
+    else
+        die "The specified file does not exist: $FILE_ARG"
+    fi
+}
+
+install_using_version() {
+    version_name=$1
+    data_dst_dir=$2
+
+    if [ -z "$(ls -A "$data_dst_dir")" ]; then
+        package_url=$(decide_package_url_for_version "$version_name")
+        package_file=$(download_package_url "$version_name" "$package_url")
+        install_from_package_file "$package_file" "$data_dst_dir"
+    else
+        info "Found an existing installation on the disk, at $data_dst_dir. Using it instead.\n"
     fi
 }
 


### PR DESCRIPTION
- On top of #5 
- On top of wasp-lang/wasp#3304
- Part of wasp-lang/wasp#3073

---

- Adds a `-f` argument to install from a local `.tar.gz`. With this, we will be able to e.g. download the artifact from a workflow run, and install it as if it was a regular version.

- We install it under `unknown` instead of an explicit version number, as we can't get it from an arbitrary path (`$HOME/.share/local/wasp/unknown` instead of `$HOME/.share/local/wasp/X.Y.Z`)