### PR TITLE
Add CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+      # TODO: remove before merging
+      - cprecioso/add-testing
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,20 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - macos-15-intel
+        shell:
+          - dash
+          - bash
+          - zsh
         args:
           - name: bare
             value: ""
           - name: versioned
             value: "-v 0.18.0"
+        exclude:
+          - { os: macos-latest, shell: dash }
+          - { os: macos-15-intel, shell: dash }
 
-    name: Test installer (${{ matrix.os }}, ${{ matrix.args.name }})
+    name: Test installer (${{ matrix.os }}, ${{ matrix.shell }}, ${{ matrix.args.name }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -33,6 +40,6 @@ jobs:
           node-version: "22"
 
       - run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
-      - run: ./installer.sh ${{ matrix.args.value }}
+      - run: ${{ matrix.shell }} ./installer.sh ${{ matrix.args.value }}
 
       - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
           - macos-latest
           - macos-15-intel
         shell:
-          - dash
-          - bash
-          - zsh
+          - dash # Minimal `sh` implementation, good for testing POSIX compliance.
+          - bash # The most common shell.
+          - zsh # The default shell on macOS.
         args:
           - name: bare
             value: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - name: versioned
             value: "-v 0.18.0"
         exclude:
-          # Dash is not available on macOS by default.
+          # Dash is not available on macOS.
           - { os: macos-latest, shell: dash }
           - { os: macos-15-intel, shell: dash }
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install shell
         if: runner.os == 'Linux'
-        run: sudo apt-get install ${{ matrix.shell }}
+        run: sudo apt-get install -y ${{ matrix.shell }}
 
       - name: Edit PATH
         run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
       - run: echo "PATH=$PATH:/root/.local/bin" >> "$GITHUB_ENV"
       - run: ./installer.sh ${{ matrix.args.value }}
+
       - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+        args:
+          - ""
+          - "-v 0.18.0"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+      - run: echo "PATH=$PATH:/root/.local/bin" >> "$GITHUB_ENV"
+      - run: installer.sh ${{ matrix.args }}
+      - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: echo "PATH=$PATH:/root/.local/bin" >> "$GITHUB_ENV"
+      - run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
       - run: ./installer.sh ${{ matrix.args.value }}
 
       - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           - name: versioned
             value: "-v 0.18.0"
         exclude:
+          # Dash is not available on macOS by default.
           - { os: macos-latest, shell: dash }
           - { os: macos-15-intel, shell: dash }
 
@@ -39,7 +40,14 @@ jobs:
         with:
           node-version: "22"
 
-      - run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
-      - run: ${{ matrix.shell }} ./installer.sh ${{ matrix.args.value }}
+      - name: Install shell
+        if: runner.os == 'Linux'
+        run: sudo apt-get install ${{ matrix.shell }}
+
+      - name: Edit PATH
+        run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
+
+      - name: Run installer
+        run: ${{ matrix.shell }} ./installer.sh ${{ matrix.args.value }}
 
       - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Test installer
+
 on:
   push:
     branches:
@@ -17,13 +19,16 @@ jobs:
           - macos-latest
           - macos-15-intel
         args:
-          - ""
-          - "-v 0.18.0"
+          - name: bare
+            value: ""
+          - name: versioned
+            value: "-v 0.18.0"
 
+    name: Test installer (${{ matrix.os }}, ${{ matrix.args.name }})
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
       - run: echo "PATH=$PATH:/root/.local/bin" >> "$GITHUB_ENV"
-      - run: installer.sh ${{ matrix.args }}
+      - run: installer.sh ${{ matrix.args.value }}
       - run: wasp version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      # TODO: remove before merging
-      - cprecioso/add-testing
   pull_request:
     branches:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 on:
   push:
     branches:
-      - main
+      - master
       # TODO: remove before merging
       - cprecioso/add-testing
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: echo "PATH=$PATH:/root/.local/bin" >> "$GITHUB_ENV"
-      - run: installer.sh ${{ matrix.args.value }}
+      - run: ./installer.sh ${{ matrix.args.value }}
       - run: wasp version


### PR DESCRIPTION
- Preparations for #6 

---

Adds a simple test to the installer, to check that a Wasp version was installed.
This is expected to just be a basic smoke check for installation.