### PR TITLE
Add lint job for shell script validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint script
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - run: shellcheck installer.sh
+
   test:
     strategy:
       matrix:


### PR DESCRIPTION
As we recommend in the README, runs shellcheck against the installer. This is easy as it is installed by default on github runner images.

I made example PRs so we can see how it looks when it fails:
- Warning: https://github.com/wasp-lang/get-wasp-sh/actions/runs/19131098744/job/54671782294?pr=10
- Error: https://github.com/wasp-lang/get-wasp-sh/actions/runs/19131112610/job/54671829466?pr=11