### PR TITLE
Remove undocumented `-f wasp-tarball` functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,6 @@ jobs:
             value: ""
           - name: versioned
             value: "-v 0.18.0"
-          - name: file path
-            value: "-f ./wasp-*.tar.gz"
-            needs-download: true
         exclude:
           # Dash is not available on macOS.
           - { os: macos-latest, shell: dash }
@@ -52,10 +49,6 @@ jobs:
       - name: Install shell
         if: runner.os == 'Linux'
         run: sudo apt-get install -y ${{ matrix.shell }}
-
-      - name: Download installer package
-        if: matrix.args.needs-download == true
-        uses: wasp-lang/wasp/.github/actions/fetch-nightly-cli@main
 
       - name: Edit PATH
         run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"

--- a/installer.sh
+++ b/installer.sh
@@ -9,7 +9,6 @@
 HOME_LOCAL_BIN="$HOME/.local/bin"
 HOME_LOCAL_SHARE="$HOME/.local/share"
 VERSION_ARG=
-FILE_ARG=
 
 RED="\033[31m"
 GREEN="\033[32m"
@@ -24,10 +23,6 @@ while [ $# -gt 0 ]; do
     #     ;;
     -v | --version)
         VERSION_ARG="$2"
-        shift 2
-        ;;
-    -f | --file)
-        FILE_ARG="$2"
         shift 2
         ;;
     *)
@@ -49,39 +44,19 @@ main() {
     data_dst_dir="$HOME_LOCAL_SHARE/wasp-lang/$version_name"
     bin_dst_dir="$HOME_LOCAL_BIN"
 
-    if [ -n "$FILE_ARG" ]; then
-        install_using_file_arg "$data_dst_dir"
-    else
-        install_using_version "$version_name" "$data_dst_dir"
-    fi
+    install_version "$version_name" "$data_dst_dir"
 
     link_wasp_version "$version_name" "$data_dst_dir" "$bin_dst_dir"
     print_tips "$bin_dst_dir"
 }
 
 decide_version_name() {
-    if [ -n "$FILE_ARG" ]; then
-        echo "unknown"
-    else
-        latest_version=$(get_latest_wasp_version)
-        version_name=${VERSION_ARG:-$latest_version}
-        echo "$version_name"
-    fi
+    latest_version=$(get_latest_wasp_version)
+    version_name=${VERSION_ARG:-$latest_version}
+    echo "$version_name"
 }
 
-install_using_file_arg() {
-    data_dst_dir=$1
-
-    info "Installing wasp from file: $FILE_ARG\n"
-
-    if [ -f "$FILE_ARG" ]; then
-        install_from_package_file "$FILE_ARG" "$data_dst_dir"
-    else
-        die "The specified file does not exist: $FILE_ARG"
-    fi
-}
-
-install_using_version() {
+install_version() {
     version_name=$1
     data_dst_dir=$2
 


### PR DESCRIPTION
- I added a functionality to install from a downloaded Wasp tarball in #6
- This was done as part of https://github.com/wasp-lang/wasp/issues/3073
- This approach was overcomplicated and undocumented. We don't need it anymore as we will fetch "nightly" binaries from pkg.pr.new in https://github.com/wasp-lang/open-saas/pull/588