### PR TITLE
Add migrate-to-npm command and version guards

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -3,11 +3,15 @@
 # NOTE: Heavily inspired by get-stack.hs script for installing stack.
 # https://raw.githubusercontent.com/commercialhaskell/stack/stable/etc/scripts/get-stack.sh
 
-# NOTE: These paths are used in the Wasp uninstall command, if you change it here,
-#       change it there as well.
-#       Link to Uninstall command: https://github.com/wasp-lang/wasp/blob/main/waspc/cli/src/Wasp/Cli/FileSystem.hs#L36
+# NOTE: These paths are also defined in:
+# - https://github.com/wasp-lang/wasp/blob/main/waspc/cli/src/Wasp/Cli/FileSystem.hs
+# - https://github.com/wasp-lang/wasp/blob/main/scripts/make-npm-packages/templates/main-package/preinstall.js
+# TODO: Do not hardcode: https://github.com/wasp-lang/wasp/issues/980
 HOME_LOCAL_BIN="$HOME/.local/bin"
 HOME_LOCAL_SHARE="$HOME/.local/share"
+WASP_LANG_DIR="$HOME_LOCAL_SHARE/wasp-lang"
+NPM_MARKER_FILE="$WASP_LANG_DIR/.uses-npm"
+NPM_MIGRATION_VERSION="0.21" # First version we'll refuse to install
 VERSION_ARG=
 
 RED="\033[31m"
@@ -25,6 +29,10 @@ while [ $# -gt 0 ]; do
         VERSION_ARG="$2"
         shift 2
         ;;
+    migrate-to-npm)
+        COMMAND="migrate-to-npm"
+        shift
+        ;;
     *)
         echo "Invalid argument: $1" >&2
         exit 1
@@ -33,43 +41,93 @@ while [ $# -gt 0 ]; do
 done
 
 main() {
+    if [ -f "$NPM_MARKER_FILE" ]; then
+        die "You are already using Wasp through npm.\n\nTo install Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, first uninstall Wasp through npm, and remove the marker file at $NPM_MARKER_FILE."
+    fi
+
+    if [ "$COMMAND" = "migrate-to-npm" ]; then
+        migrate_to_npm
+        exit 0
+    fi
+
+    # Require version argument
+    if [ -z "$VERSION_ARG" ]; then
+        die "A version argument is required.\n\nUsage: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v <version>\n\nFor Wasp $NPM_MIGRATION_VERSION and later, please use npm:\n  npm install -g @wasp.sh/wasp-cli"
+    fi
+
+    # Check version restrictions - reject when requested version >= migration version
+    if version_gte "$VERSION_ARG" "$NPM_MIGRATION_VERSION"; then
+        die "Wasp version $VERSION_ARG and later must be installed via npm.\n\nPlease run: npm install -g @wasp.sh/wasp-cli@$VERSION_ARG\n\nTo migrate from installer to npm, run:\n  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- migrate-to-npm"
+    fi
+
+    # Warn about installing old version
+    info "${RED}WARNING${RESET}: You are installing an older version of Wasp ($VERSION_ARG)."
+    info "Starting with Wasp $NPM_MIGRATION_VERSION, the installer is deprecated and npm is the preferred installation method:\n  npm install -g @wasp.sh/wasp-cli\n"
+
     trap cleanup_temp_dir EXIT
     send_telemetry >/dev/null 2>&1 &
-
-    version_name=$(decide_version_name)
 
     # TODO: Consider installing into /usr/local/bin and /usr/local/share instead of into
     #   ~/.local/share and ~/.local/bin, since those are always on the PATH and are standard
     #  to install programs like this. But then we need to run some commands below with sudo.
-    data_dst_dir="$HOME_LOCAL_SHARE/wasp-lang/$version_name"
+    data_dst_dir="$HOME_LOCAL_SHARE/wasp-lang/$VERSION_ARG"
     bin_dst_dir="$HOME_LOCAL_BIN"
 
-    install_version "$version_name" "$data_dst_dir"
+    install_version "$VERSION_ARG" "$data_dst_dir"
 
-    link_wasp_version "$version_name" "$data_dst_dir" "$bin_dst_dir"
+    link_wasp_version "$VERSION_ARG" "$data_dst_dir" "$bin_dst_dir"
     print_tips "$bin_dst_dir"
 }
 
-decide_version_name() {
-    latest_version=$(get_latest_wasp_version)
-    version_name=${VERSION_ARG:-$latest_version}
-    echo "$version_name"
+# Migrate from installer-based Wasp to npm-based Wasp.
+migrate_to_npm() {
+    info "Migrating from installer-based Wasp to npm-based Wasp...\n"
+
+    # Remove installer Wasp binary
+    wasp_bin="$HOME_LOCAL_BIN/wasp"
+    if [ -f "$wasp_bin" ]; then
+        info "Removing Wasp executable at $wasp_bin..."
+        rm -f "$wasp_bin" || die "Failed to remove $wasp_bin"
+    fi
+
+    # Remove version directories but keep the wasp-lang dir for the marker
+    if [ -d "$WASP_LANG_DIR" ]; then
+        info "Removing installer version directories..."
+        for dir in "$WASP_LANG_DIR"/*/; do
+            info "Removing $dir..."
+            if [ -d "$dir" ]; then
+                rm -rf "$dir" || die "Failed to remove $dir"
+            fi
+        done
+    fi
+
+    # Create marker file (ensure directory exists)
+    create_dir_if_missing "$WASP_LANG_DIR"
+    touch "$NPM_MARKER_FILE" || die "Failed to create npm marker file at $NPM_MARKER_FILE"
+
+    info "\n${GREEN}Ready for the next step!${RESET}\n"
+    info "Now you can install Wasp via npm, running the following command:"
+    info "  ${BOLD}npm install -g @wasp.sh/wasp-cli${RESET}\n"
+}
+
+# Compare two semver versions (major.minor only).
+# Returns 0 (true) if v1 >= v2, 1 (false) otherwise.
+version_gte() {
+    v1_major=$(echo "$1" | cut -d. -f1)
+    v1_minor=$(echo "$1" | cut -d. -f2)
+    v2_major=$(echo "$2" | cut -d. -f1)
+    v2_minor=$(echo "$2" | cut -d. -f2)
+
+    [ "$v1_major" -gt "$v2_major" ] && return 0
+    [ "$v1_major" -lt "$v2_major" ] && return 1
+    [ "$v1_minor" -ge "$v2_minor" ]
 }
 
 install_version() {
     version_name=$1
     data_dst_dir=$2
 
-    latest_version=$(get_latest_wasp_version)
-
-    latest_version_message=
-    if [ "$version_name" = "$latest_version" ]; then
-        latest_version_message="latest"
-    else
-        latest_version_message="latest is $latest_version"
-    fi
-
-    info "Installing wasp version $version_name ($latest_version_message).\n"
+    info "Installing wasp version $version_name.\n"
 
     if [ -z "$(ls -A "$data_dst_dir")" ]; then
         package_url=$(decide_package_url_for_version "$version_name")
@@ -324,35 +382,6 @@ get_os_info() {
         echo "Unknown"
         ;;
     esac
-}
-
-# Don't use directly, use the get_latest_wasp_version function.
-WASP_LATEST_VERSION=
-
-# Gets the latest wasp version from GitHub releases. Caches the result so we only
-# do the network request once.
-get_latest_wasp_version() {
-    if [ -z "$WASP_LATEST_VERSION" ]; then
-        releases_url="https://github.com/wasp-lang/wasp/releases/latest"
-
-        if has_curl; then
-            WASP_LATEST_VERSION=$(
-                curl -LIs -o /dev/null -w '%{url_effective}' $releases_url |
-                    awk -F/ '{print $NF}' |
-                    cut -c2-
-            )
-        elif has_wget; then
-            WASP_LATEST_VERSION=$(
-                wget --spider --max-redirect=0 $releases_url 2>&1 |
-                    awk '/Location: /,// { print }' |
-                    awk '{print $2}' |
-                    awk -F/ '{print $NF}' |
-                    cut -c2-
-            )
-        fi
-    fi
-
-    echo "$WASP_LATEST_VERSION"
 }
 
 main


### PR DESCRIPTION
## Summary

- Adds `migrate-to-npm` command that removes installer Wasp and creates npm marker
- Requires explicit version argument for all installs
- Rejects installing versions >= 0.21 (directs to npm)
- Rejects installing if npm marker exists
- Warns when installing older versions
- Preserves cache directory for telemetry continuity

This is part of the migration from installer to npm distribution. The companion PR for the npm package changes is in the wasp repo.

Fixes wasp-lang/wasp#3707

## Test plan

- [ ] Test `migrate-to-npm` command - should remove installer and create marker
- [ ] Test installer without version arg - should fail requiring version
- [ ] Test installer with version >= 0.21 - should fail directing to npm
- [ ] Test installer with version < 0.21 - should work with warning
- [ ] Test installer with npm marker present - should fail directing to npm

🤖 Generated with [Claude Code](https://claude.ai/code)