### PR TITLE
npm Migration 1: Add migrate-to-npm command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,47 @@ jobs:
         run: ${{ matrix.shell }} ./installer.sh ${{ matrix.args.value }}
 
       - run: wasp version
+
+  test-migrate-to-npm:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+        shell:
+          - dash # Minimal `sh` implementation, good for testing POSIX compliance.
+          - bash # The most common shell.
+          - zsh # The default shell on macOS.
+        exclude:
+          # Dash is not available on macOS.
+          - { os: macos-latest, shell: dash }
+          - { os: macos-15-intel, shell: dash }
+
+    name: Test migrate-to-npm (${{ matrix.os }}, ${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install shell
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ${{ matrix.shell }}
+
+      - name: Edit PATH
+        run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
+
+      - name: Install wasp first
+        run: ${{ matrix.shell }} ./installer.sh
+
+      - name: Verify wasp is installed
+        run: wasp version
+
+      - name: Run migrate-to-npm
+        run: ${{ matrix.shell }} ./installer.sh migrate-to-npm
+
+      - name: Verify npm marker file exists
+        run: test -f "$HOME/.local/share/wasp-lang/.uses-npm"
+
+      - name: Verify wasp binary is removed
+        run: test ! -f "$HOME/.local/bin/wasp"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
       - name: Install shell
         if: runner.os == 'Linux'
         run: sudo apt-get install -y ${{ matrix.shell }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,6 @@ jobs:
 
       - name: Verify wasp binary is removed
         run: test ! -f "$HOME/.local/bin/wasp"
+
+      - name: Verify wasp-lang doesn't contain any version directories
+        run: test -z "$(find "$HOME/.local/share/wasp-lang" -mindepth 1 -maxdepth 1 -type d)"

--- a/installer.sh
+++ b/installer.sh
@@ -47,7 +47,7 @@ main() {
     fi
 
     if [ -f "$NPM_MARKER_FILE" ]; then
-        die "You are already using Wasp through npm.\n\nTo install Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, first uninstall Wasp through npm, and remove the marker file at $NPM_MARKER_FILE."
+        die "You are already using Wasp through npm.\n\nTo install the latest version of Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, check our guide at:\n  https://wasp.sh/docs/guides/legacy/installer"
     fi
 
     if [ -n "$MIGRATE_TO_NPM_ARG" ]; then

--- a/installer.sh
+++ b/installer.sh
@@ -72,7 +72,6 @@ decide_version_name() {
     echo "$version_name"
 }
 
-# Migrate from installer-based Wasp to npm-based Wasp.
 migrate_to_npm() {
     info "Migrating from installer-based Wasp to npm-based Wasp...\n"
 
@@ -94,7 +93,6 @@ migrate_to_npm() {
         done
     fi
 
-    # Create marker file (ensure directory exists)
     create_dir_if_missing "$WASP_LANG_DIR"
     touch "$NPM_MARKER_FILE" || die "Failed to create npm marker file at $NPM_MARKER_FILE"
 

--- a/installer.sh
+++ b/installer.sh
@@ -103,7 +103,7 @@ migrate_to_npm() {
     touch "$NPM_MARKER_FILE" || die "Failed to create npm marker file at $NPM_MARKER_FILE"
 
     info "\n${GREEN}Ready for the next step!${RESET}\n"
-    info "Now you can install Wasp via npm, running the following command:"
+    info "Now you can install Wasp via npm by running the following command:"
     info "  ${BOLD}npm install -g @wasp.sh/wasp-cli${RESET}\n"
 }
 

--- a/installer.sh
+++ b/installer.sh
@@ -11,6 +11,8 @@ HOME_LOCAL_BIN="$HOME/.local/bin"
 HOME_LOCAL_SHARE="$HOME/.local/share"
 WASP_LANG_DIR="$HOME_LOCAL_SHARE/wasp-lang"
 NPM_MARKER_FILE="$WASP_LANG_DIR/.uses-npm"
+
+MIGRATE_TO_NPM_ARG=
 VERSION_ARG=
 
 RED="\033[31m"
@@ -29,7 +31,7 @@ while [ $# -gt 0 ]; do
         shift 2
         ;;
     migrate-to-npm)
-        COMMAND="migrate-to-npm"
+        MIGRATE_TO_NPM_ARG=1
         shift
         ;;
     *)
@@ -40,11 +42,15 @@ while [ $# -gt 0 ]; do
 done
 
 main() {
+    if [ -n "$VERSION_ARG" ] && [ -n "$MIGRATE_TO_NPM_ARG" ]; then
+        die "Error: Cannot use both -v/--version and migrate-to-npm arguments together.\n  Use either -v/--version to install a specific version, or migrate-to-npm to migrate to npm."
+    fi
+
     if [ -f "$NPM_MARKER_FILE" ]; then
         die "You are already using Wasp through npm.\n\nTo install Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, first uninstall Wasp through npm, and remove the marker file at $NPM_MARKER_FILE."
     fi
 
-    if [ "$COMMAND" = "migrate-to-npm" ]; then
+    if [ -n "$MIGRATE_TO_NPM_ARG" ]; then
         migrate_to_npm
         exit 0
     fi


### PR DESCRIPTION
## Summary

Add a migrate-to-npm command to help users transition from installer-based Wasp to npm-based Wasp.

## Changes

- Add `migrate-to-npm` command that:
  - Removes the installer-based Wasp binary
  - Cleans up version directories
  - Creates a marker file to prevent future installer usage
  - Provides instructions for installing via npm
- Add CI tests for the migrate-to-npm command

## Part of stacked PRs

This is part 1 of 5:
1. **This PR**
2. #16
3. #17
4. #18
5. #19