### PR TITLE
npm Migration 2: Reject installation for newer Wasp versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,47 @@ jobs:
         run: ${{ matrix.shell }} ./installer.sh ${{ matrix.args.value }}
 
       - run: wasp version
+
+  test-migrate-to-npm:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+        shell:
+          - dash # Minimal `sh` implementation, good for testing POSIX compliance.
+          - bash # The most common shell.
+          - zsh # The default shell on macOS.
+        exclude:
+          # Dash is not available on macOS.
+          - { os: macos-latest, shell: dash }
+          - { os: macos-15-intel, shell: dash }
+
+    name: Test migrate-to-npm (${{ matrix.os }}, ${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install shell
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ${{ matrix.shell }}
+
+      - name: Edit PATH
+        run: echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
+
+      - name: Install wasp first
+        run: ${{ matrix.shell }} ./installer.sh
+
+      - name: Verify wasp is installed
+        run: wasp version
+
+      - name: Run migrate-to-npm
+        run: ${{ matrix.shell }} ./installer.sh migrate-to-npm
+
+      - name: Verify npm marker file exists
+        run: test -f "$HOME/.local/share/wasp-lang/.uses-npm"
+
+      - name: Verify wasp binary is removed
+        run: test ! -f "$HOME/.local/bin/wasp"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
       - name: Install shell
         if: runner.os == 'Linux'
         run: sudo apt-get install -y ${{ matrix.shell }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,3 +101,40 @@ jobs:
 
       - name: Verify wasp binary is removed
         run: test ! -f "$HOME/.local/bin/wasp"
+
+  test-version-rejection:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+        shell:
+          - dash # Minimal `sh` implementation, good for testing POSIX compliance.
+          - bash # The most common shell.
+          - zsh # The default shell on macOS.
+        version:
+          - "0.21"
+          - "0.22"
+          - "1.1"
+        exclude:
+          # Dash is not available on macOS.
+          - { os: macos-latest, shell: dash }
+          - { os: macos-15-intel, shell: dash }
+
+    name: Test version rejection (${{ matrix.os }}, ${{ matrix.shell }}, ${{ matrix.version }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install shell
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ${{ matrix.shell }}
+
+      - name: Try to install version ${{ matrix.version }} (should fail)
+        run: |
+          if ${{ matrix.shell }} ./installer.sh -v ${{ matrix.version }}; then
+            echo "ERROR: Installer should have rejected version ${{ matrix.version }}"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,6 @@ jobs:
 
       - name: Verify wasp binary is removed
         run: test ! -f "$HOME/.local/bin/wasp"
+
+      - name: Verify wasp-lang doesn't contain any version directories
+        run: test -z "$(find "$HOME/.local/share/wasp-lang" -mindepth 1 -maxdepth 1 -type d)"

--- a/installer.sh
+++ b/installer.sh
@@ -44,7 +44,7 @@ done
 
 main() {
     if [ -n "$VERSION_ARG" ] && [ -n "$MIGRATE_TO_NPM_ARG" ]; then
-        die "Error: Cannot use both -v/--version and migrate-to-npm arguments together.\n  Use either -v/--version to install a specific version, or migrate-to-npm to migrate to npm."
+        die "Error: Cannot use both -v/--version and migrate-to-npm arguments together.\nUse either -v/--version to install a specific version, or migrate-to-npm to migrate to npm."
     fi
 
     if [ -f "$NPM_MARKER_FILE" ]; then
@@ -60,12 +60,12 @@ main() {
     if [ -n "$VERSION_ARG" ]; then
         # Check version restrictions - reject when requested version >= migration version
         if version_gte "$VERSION_ARG" "$NPM_MIGRATION_VERSION"; then
-            die "Wasp version $NPM_MIGRATION_VERSION and later must be installed via npm.\n\nPlease run: npm install -g @wasp.sh/wasp-cli@$VERSION_ARG\n\nTo migrate from installer to npm, run:\n  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- migrate-to-npm"
+            die "Wasp version $NPM_MIGRATION_VERSION and later must be installed via npm.\n\nIf you've already installed Wasp from installer, please migrate to the npm method first:\n  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- migrate-to-npm\n\nTo install Wasp through npm, please run:\n  npm install -g @wasp.sh/wasp-cli@$VERSION_ARG\n\nYou can read more about this migration at:\n  https://wasp.sh/docs/guides/legacy/installer"
         fi
 
         # Warn about installing old version
         info "${RED}WARNING${RESET}: You are installing an older version of Wasp ($VERSION_ARG)."
-        info "Starting with Wasp $NPM_MIGRATION_VERSION, the installer is deprecated and npm is the preferred installation method:\n  npm install -g @wasp.sh/wasp-cli\n"
+        info "Starting with Wasp $NPM_MIGRATION_VERSION, the installer is deprecated and npm is the preferred installation method:\n  npm install -g @wasp.sh/wasp-cli\n\nYou can read more about this migration at:\n  https://wasp.sh/docs/guides/legacy/installer"
     fi
 
     trap cleanup_temp_dir EXIT

--- a/installer.sh
+++ b/installer.sh
@@ -47,7 +47,7 @@ main() {
     fi
 
     if [ -f "$NPM_MARKER_FILE" ]; then
-        die "You are already using Wasp through npm.\n\nTo install Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, first uninstall Wasp through npm, and remove the marker file at $NPM_MARKER_FILE."
+        die "You are already using Wasp through npm.\n\nTo install the latest version of Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, check our guide at:\n  https://wasp.sh/docs/guides/legacy/installer"
     fi
 
     if [ -n "$MIGRATE_TO_NPM_ARG" ]; then

--- a/installer.sh
+++ b/installer.sh
@@ -54,7 +54,7 @@ main() {
     if [ -n "$VERSION_ARG" ]; then
         # Check version restrictions - reject when requested version >= migration version
         if version_gte "$VERSION_ARG" "$NPM_MIGRATION_VERSION"; then
-            die "Wasp version $VERSION_ARG and later must be installed via npm.\n\nPlease run: npm install -g @wasp.sh/wasp-cli@$VERSION_ARG\n\nTo migrate from installer to npm, run:\n  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- migrate-to-npm"
+            die "Wasp version $NPM_MIGRATION_VERSION and later must be installed via npm.\n\nPlease run: npm install -g @wasp.sh/wasp-cli@$VERSION_ARG\n\nTo migrate from installer to npm, run:\n  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- migrate-to-npm"
         fi
 
         # Warn about installing old version

--- a/installer.sh
+++ b/installer.sh
@@ -72,7 +72,6 @@ decide_version_name() {
     echo "$version_name"
 }
 
-# Migrate from installer-based Wasp to npm-based Wasp.
 migrate_to_npm() {
     info "Migrating from installer-based Wasp to npm-based Wasp...\n"
 
@@ -94,7 +93,6 @@ migrate_to_npm() {
         done
     fi
 
-    # Create marker file (ensure directory exists)
     create_dir_if_missing "$WASP_LANG_DIR"
     touch "$NPM_MARKER_FILE" || die "Failed to create npm marker file at $NPM_MARKER_FILE"
 

--- a/installer.sh
+++ b/installer.sh
@@ -65,7 +65,7 @@ main() {
 
         # Warn about installing old version
         info "${RED}WARNING${RESET}: You are installing an older version of Wasp ($VERSION_ARG)."
-        info "Starting with Wasp $NPM_MIGRATION_VERSION, the installer is deprecated and npm is the preferred installation method:\n  npm install -g @wasp.sh/wasp-cli\n\nYou can read more about this migration at:\n  https://wasp.sh/docs/guides/legacy/installer"
+        info "Starting with Wasp $NPM_MIGRATION_VERSION, the installer is deprecated and npm is the preferred installation method. You can read more about the migration at:\n  https://wasp.sh/docs/guides/legacy/installer"
     fi
 
     trap cleanup_temp_dir EXIT

--- a/installer.sh
+++ b/installer.sh
@@ -103,7 +103,7 @@ migrate_to_npm() {
     touch "$NPM_MARKER_FILE" || die "Failed to create npm marker file at $NPM_MARKER_FILE"
 
     info "\n${GREEN}Ready for the next step!${RESET}\n"
-    info "Now you can install Wasp via npm, running the following command:"
+    info "Now you can install Wasp via npm by running the following command:"
     info "  ${BOLD}npm install -g @wasp.sh/wasp-cli${RESET}\n"
 }
 

--- a/installer.sh
+++ b/installer.sh
@@ -11,7 +11,7 @@ HOME_LOCAL_BIN="$HOME/.local/bin"
 HOME_LOCAL_SHARE="$HOME/.local/share"
 WASP_LANG_DIR="$HOME_LOCAL_SHARE/wasp-lang"
 NPM_MARKER_FILE="$WASP_LANG_DIR/.uses-npm"
-NPM_MIGRATION_VERSION="0.21" # First version we'll refuse to install
+NPM_MIGRATION_VERSION="0.21" # First version we'll refuse to install through installer
 
 MIGRATE_TO_NPM_ARG=
 VERSION_ARG=

--- a/installer.sh
+++ b/installer.sh
@@ -11,6 +11,8 @@ HOME_LOCAL_BIN="$HOME/.local/bin"
 HOME_LOCAL_SHARE="$HOME/.local/share"
 WASP_LANG_DIR="$HOME_LOCAL_SHARE/wasp-lang"
 NPM_MARKER_FILE="$WASP_LANG_DIR/.uses-npm"
+
+MIGRATE_TO_NPM_ARG=
 VERSION_ARG=
 
 RED="\033[31m"
@@ -29,7 +31,7 @@ while [ $# -gt 0 ]; do
         shift 2
         ;;
     migrate-to-npm)
-        COMMAND="migrate-to-npm"
+        MIGRATE_TO_NPM_ARG=1
         shift
         ;;
     *)
@@ -40,11 +42,15 @@ while [ $# -gt 0 ]; do
 done
 
 main() {
+    if [ -n "$VERSION_ARG" ] && [ -n "$MIGRATE_TO_NPM_ARG" ]; then
+        die "Error: Cannot use both -v/--version and migrate-to-npm arguments together.\n  Use either -v/--version to install a specific version, or migrate-to-npm to migrate to npm."
+    fi
+
     if [ -f "$NPM_MARKER_FILE" ]; then
         die "You are already using Wasp through npm.\n\nTo install Wasp, run:\n  npm install -g @wasp.sh/wasp-cli\n\nIf you need to use the installer again, first uninstall Wasp through npm, and remove the marker file at $NPM_MARKER_FILE."
     fi
 
-    if [ "$COMMAND" = "migrate-to-npm" ]; then
+    if [ -n "$MIGRATE_TO_NPM_ARG" ]; then
         migrate_to_npm
         exit 0
     fi


### PR DESCRIPTION
## Summary

Prevent installer from installing Wasp 0.21 and later, which should be installed via npm instead.

## Changes

- Add version checking with `version_gte()` function
- Reject installation attempts for Wasp 0.21+
- Display error message with npm installation instructions
- Display warning when installing older versions

## Part of stacked PRs

This is part 2 of 5:
1. #15
2. **This PR**
3. #17
4. #18
5. #19